### PR TITLE
Issue #5 - Upgrade to MusicPlayer 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is this?
 
-This is an extension for the [musicplayer](https://github.com/scorbo2/musicplayer) application which allows
+This is an extension for the [MusicPlayer](https://github.com/scorbo2/musicplayer) application which allows
 tracking of how many times each track is played, so you can view listening statistics in the stats dialog.
 
 ## How do I get it?
@@ -23,7 +23,7 @@ on the "Installed" tab, and hit the "uninstall" button in the top right. It's ju
 ### Option 2: manual download and installation
 
 Alternatively, you can manually download the extension jar: 
-[ext-mp-stats-tracker-3.1.0.jar](http://www.corbett.ca/apps/MusicPlayer/extensions/3.1/ext-mp-stats-tracker-3.1.0.jar)
+[ext-mp-stats-tracker-4.0.0.jar](http://www.corbett.ca/apps/MusicPlayer/extensions/4.0/ext-mp-stats-tracker-4.0.0.jar)
 
 Then save it in your ~/.MusicPlayer/extensions directory and restart the application.
 
@@ -34,10 +34,10 @@ You can clone this repo and build the extension jar with maven (Java 17 or highe
 ```shell
 git clone https://github.com/scorbo2/ext-mp-stats-tracker.git
 cd ext-mp-stats-tracker
-mvn package # NOTE! You must have MusicPlayer-3.1 in your local maven repository for this to work!
+mvn package # NOTE! You must have MusicPlayer-4.0 in your local maven repository for this to work!
 
 # Copy the result to the extensions directory:
-cp target/ext-mp-stats-tracker-3.1.0.jar ~/.MusicPlayer/extensions
+cp target/ext-mp-stats-tracker-4.0.0.jar ~/.MusicPlayer/extensions
 ```
 ## Okay, it's installed, how do I use it?
 
@@ -51,7 +51,7 @@ This shows you a list of your top 10 most listened-to tracks, along with the tot
 
 ### Requirements
 
-MusicPlayer 3.1 or higher.
+Compatible with any `4.x` release of the MusicPlayer application.
 
 ### License
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>ext-mp-stats-tracker</artifactId>
-    <version>3.1.0</version>
+    <version>4.0.0</version>
 
     <dependencies>
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>musicplayer</artifactId>
-            <version>3.1</version>
+            <version>4.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/ca/corbett/musicplayer/extensions/statstracker/StatsTrackerExtension.java
+++ b/src/main/java/ca/corbett/musicplayer/extensions/statstracker/StatsTrackerExtension.java
@@ -1,15 +1,19 @@
 package ca.corbett.musicplayer.extensions.statstracker;
 
 import ca.corbett.extensions.AppExtensionInfo;
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.MessageUtil;
+import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.KeyStrokeProperty;
 import ca.corbett.musicplayer.extensions.MusicPlayerExtension;
 import ca.corbett.musicplayer.ui.AudioPanel;
 import ca.corbett.musicplayer.ui.AudioPanelListener;
 import ca.corbett.musicplayer.ui.MainWindow;
 import ca.corbett.musicplayer.ui.VisualizationTrackInfo;
 
-import java.awt.event.KeyEvent;
+import java.awt.event.ActionEvent;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -45,7 +49,13 @@ public class StatsTrackerExtension extends MusicPlayerExtension implements Audio
 
     @Override
     protected List<AbstractProperty> createConfigProperties() {
-        return List.of();
+        List<AbstractProperty> props = new ArrayList<>();
+        props.add(new KeyStrokeProperty("Statistics.options.viewStatsKey",
+                                        "View statistics:",
+                                        KeyStrokeManager.parseKeyStroke("Ctrl+T"),
+                                        new LaunchDialogAction())
+                      .setExposed(false)); // not user-configurable
+        return props;
     }
 
     @Override
@@ -73,25 +83,27 @@ public class StatsTrackerExtension extends MusicPlayerExtension implements Audio
     public void audioLoaded(AudioPanel sourcePanel, VisualizationTrackInfo trackInfo) {
     }
 
-    @Override
-    public boolean handleKeyEvent(KeyEvent keyEvent) {
-        if (keyEvent.isControlDown() && keyEvent.getKeyCode() == KeyEvent.VK_T) {
-            List<StatsDb.Entry> top10 = statsDb.getTop10();
-            if (top10.isEmpty()) {
-                getMessageUtil().info("No statistics data yet!");
-                return true;
-            }
-            new Top10Dialog(statsDb, top10).setVisible(true);
-            return true;
-        }
-
-        return false;
-    }
-
     private MessageUtil getMessageUtil() {
         if (messageUtil == null) {
             messageUtil = new MessageUtil(MainWindow.getInstance(), log);
         }
         return messageUtil;
+    }
+
+    private class LaunchDialogAction extends EnhancedAction {
+
+        public LaunchDialogAction() {
+            super("View your listening stats");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            List<StatsDb.Entry> top10 = statsDb.getTop10();
+            if (top10.isEmpty()) {
+                getMessageUtil().info("No statistics data yet!");
+                return;
+            }
+            new Top10Dialog(statsDb, top10).setVisible(true);
+        }
     }
 }

--- a/src/main/java/ca/corbett/musicplayer/extensions/statstracker/Top10Dialog.java
+++ b/src/main/java/ca/corbett/musicplayer/extensions/statstracker/Top10Dialog.java
@@ -1,6 +1,6 @@
 package ca.corbett.musicplayer.extensions.statstracker;
 
-import ca.corbett.extras.properties.PropertiesDialog;
+import ca.corbett.extras.ScrollUtil;
 import ca.corbett.forms.FormPanel;
 import ca.corbett.forms.fields.LabelField;
 import ca.corbett.forms.fields.PanelField;
@@ -58,6 +58,6 @@ public class Top10Dialog extends JDialog {
         container.add(button);
         panel.add(panelField);
         setLayout(new BorderLayout());
-        add(PropertiesDialog.buildScrollPane(panel), BorderLayout.CENTER);
+        add(ScrollUtil.buildScrollPane(panel), BorderLayout.CENTER);
     }
 }

--- a/src/main/resources/ca/corbett/musicplayer/extensions/statstracker/extInfo.json
+++ b/src/main/resources/ca/corbett/musicplayer/extensions/statstracker/extInfo.json
@@ -1,9 +1,9 @@
 {
   "name": "Stats tracker",
   "author": "steve@corbett.ca",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "targetAppName": "MusicPlayer",
-  "targetAppVersion": "3.1",
+  "targetAppVersion": "4.0",
   "shortDescription": "Keeps track of statistics for tracks played",
   "longDescription": "Hit Ctrl+T to check out the statistics dialog to see which tracks you play the most frequently!",
   "customFields": {


### PR DESCRIPTION
This PR addresses issue #5 by upgrading this extension to conform to the latest version `4.0` of the parent application.

There were breaking changes in this major release that require changes here:

- The old `handleKeyEvent` has been removed in favor of new `KeyStrokeProperty` instances
- All action classes should extend the new `EnhancedAction` parent class
- Minor: the `buildScrollPane` utility method has moved to a new `ScrollUtil` utility class.

Closes #5 